### PR TITLE
ローカルファイルが dependencyの場合も存在チェックする

### DIFF
--- a/misc/mocks/mock-pack01/package-lock.json
+++ b/misc/mocks/mock-pack01/package-lock.json
@@ -50,6 +50,12 @@
       "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
       "dev": true
     },
+    "semver": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.1.1.tgz",
+      "integrity": "sha512-rWYq2e5iYW+fFe/oPPtYJxYgjBm8sC4rmoGdUOgBB7VnwKt6HrL793l2voH1UlsyYZpJ4g0wfjnTEO1s1NP2eQ==",
+      "dev": true
+    },
     "supports-color": {
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",

--- a/misc/mocks/mock-pack01/package.json
+++ b/misc/mocks/mock-pack01/package.json
@@ -1,6 +1,7 @@
 {
   "name": "mock-pack-01",
   "devDependencies": {
-    "chalk": "*"
+    "chalk": "*",
+    "semver": ">=6"
   }
 }

--- a/misc/mocks/mock-pack02/package-lock.json
+++ b/misc/mocks/mock-pack02/package-lock.json
@@ -1,0 +1,11 @@
+{
+  "name": "mock-pack-01",
+  "requires": true,
+  "lockfileVersion": 1,
+  "dependencies": {
+    "mock-pack01": {
+      "version": "file:../mock-pack01",
+      "dev": true
+    }
+  }
+}

--- a/misc/mocks/mock-pack02/package.json
+++ b/misc/mocks/mock-pack02/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "mock-pack-02",
+  "devDependencies": {
+    "mock-pack01": "file:../mock-pack01"
+  }
+}

--- a/test.js
+++ b/test.js
@@ -3,9 +3,10 @@
  */
 'use strict'
 
+const fs = require('fs')
 const lib = require('./lib')
 const index = require('./index')
-const { equal, ok } = require('assert').strict
+const { equal, ok, doesNotReject } = require('assert').strict
 
 describe('Install if needed', async function () {
   this.timeout(40 * 1000)
@@ -18,6 +19,13 @@ describe('Install if needed', async function () {
     await lib({
       cwd: `${__dirname}/misc/mocks/mock-pack01`,
     })
+  })
+
+  it('Install mock dir2: locale file dependency', async () => {
+    await lib({
+      cwd: `${__dirname}/misc/mocks/mock-pack02`,
+    })
+    await doesNotReject(() => fs.promises.stat(`${__dirname}/misc/mocks/mock-pack02/node_modules/mock-pack01`))
   })
 })
 


### PR DESCRIPTION
`file:..` が filter されるようになっていたが、挙動を以下に変更しました

+ version 文字列が valid な semver かどうかをチェックする (`"file:..."` は除外される)
+ semver ならversionの一致を確認する
