### PR TITLE
FIX module resolution

### DIFF
--- a/lib.js
+++ b/lib.js
@@ -56,9 +56,9 @@ const utils = {
 
   modulePackagePath (name, { cwd }) {
     const moduleIds = [
+      `${cwd}/node_modules/${name}/package.json`,
       `${name}/package.json`,
       `node_modules/${name}/package.json`,
-      `${cwd}/node_modules/${name}/package.json`
     ]
     for (const moduleId of moduleIds) {
       try {

--- a/misc/mocks/mock-pack03/package-lock.json
+++ b/misc/mocks/mock-pack03/package-lock.json
@@ -1,0 +1,13 @@
+{
+  "name": "mock-pack-03",
+  "requires": true,
+  "lockfileVersion": 1,
+  "dependencies": {
+    "semver": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz",
+      "integrity": "sha1-MAvG4OhjdPe6YQaLWx7NV/xlMto=",
+      "dev": true
+    }
+  }
+}

--- a/misc/mocks/mock-pack03/package.json
+++ b/misc/mocks/mock-pack03/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "mock-pack-03",
+  "devDependencies": {
+    "semver": "^4.0.0"
+  }
+}

--- a/test.js
+++ b/test.js
@@ -19,13 +19,31 @@ describe('Install if needed', async function () {
     await lib({
       cwd: `${__dirname}/misc/mocks/mock-pack01`,
     })
+    const wasInstalled = await lib({
+      cwd: `${__dirname}/misc/mocks/mock-pack01`,
+    })
+    ok(!wasInstalled)
   })
 
   it('Install mock dir2: locale file dependency', async () => {
     await lib({
       cwd: `${__dirname}/misc/mocks/mock-pack02`,
     })
+    const wasInstalled = await lib({
+      cwd: `${__dirname}/misc/mocks/mock-pack02`,
+    })
+    ok(!wasInstalled)
     await doesNotReject(() => fs.promises.stat(`${__dirname}/misc/mocks/mock-pack02/node_modules/mock-pack01`))
+  })
+
+  it('Install mock dir3: npm-install-if-needed が上のパッケージでインストールされているときにも正しく解決する', async () => {
+    await lib({
+      cwd: `${__dirname}/misc/mocks/mock-pack03`,
+    })
+    const wasInstalled = await lib({
+      cwd: `${__dirname}/misc/mocks/mock-pack03`,
+    })
+    ok(!wasInstalled)
   })
 })
 


### PR DESCRIPTION
モジュール解決の不具合を修正した。（順番を変えた）

いくらか複雑ですが、こうなっているとします。

```
project/
├── sub-pkg
│   └── package.json
└── package.json
```

* `project/package.json` の dependencies に `npm-install-if-needed` がインストールされている
* `project/package.json` の dependencies に `"some-package": "^1.0.0"`  がある
* `project/sub-pkg/package.json` の dependencies に `"some-package": "^2.0.0"`  がある

このとき、project/sub-pkg で `npm-install-in-needed` を実行すると、毎回 npm install が行われる。

理由は modulePackagePath() 関数の中の require.resolve() の挙動にある。

* `npm-install-in-needed` は project/node_modules/npm-install-in-needed にある
* そのため require.resolve() は最初に project/node_modules を探す
* 最初に見つかる `some-package` はバージョン `1.0.0` なので、期待したバージョンと食い違う
* そのため npm install が必要と判断される
