### PR TITLE
node_modulesがなければnpm installする

### DIFF
--- a/lib.js
+++ b/lib.js
@@ -16,6 +16,7 @@ const fs = require('fs')
 
 const readFileAsync = promisify(fs.readFile)
 const findupAsync = promisify(findup)
+const statAsync = promisify(fs.stat)
 
 const utils = {
   async packageForDir (cwd) {
@@ -85,6 +86,13 @@ installIfNeeded.needsInstall = async (pkg, { cwd }) => {
   const deps = {
     ...(pkg.dependencies || {}),
     ...(process.env.NODE_ENV === 'production' ? {} : (pkg.devDependencies || {}))
+  }
+  const foundNodeModules = await statAsync(`${cwd}/node_modules`)
+    .then(() => true)
+    .catch(() => false)
+  if (!foundNodeModules) {
+    debug('Not found node_modules')
+    return true
   }
   for (const [name, version] of Object.entries(deps)) {
     const modulePackagePath = utils.modulePackagePath(name, { cwd })

--- a/misc/mocks/mock-pack02/package-lock.json
+++ b/misc/mocks/mock-pack02/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "mock-pack-01",
+  "name": "mock-pack-02",
   "requires": true,
   "lockfileVersion": 1,
   "dependencies": {

--- a/misc/mocks/mock-pack04/.gitignore
+++ b/misc/mocks/mock-pack04/.gitignore
@@ -1,0 +1,1 @@
+npm-install-done

--- a/misc/mocks/mock-pack04/package-lock.json
+++ b/misc/mocks/mock-pack04/package-lock.json
@@ -1,0 +1,4 @@
+{
+  "name": "mock-pack-04",
+  "lockfileVersion": 1
+}

--- a/misc/mocks/mock-pack04/package.json
+++ b/misc/mocks/mock-pack04/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "mock-pack-04",
+  "devDependencies": {},
+  "scripts": {
+    "postinstall": "touch npm-install-done"
+  }
+}

--- a/test.js
+++ b/test.js
@@ -45,6 +45,13 @@ describe('Install if needed', async function () {
     })
     ok(!wasInstalled)
   })
+
+  it('Install mock dir4: npm install if node_modules are not found', async () => {
+    await lib({
+      cwd: `${__dirname}/misc/mocks/mock-pack04`,
+    })
+    await doesNotReject(() => fs.promises.stat(`${__dirname}/misc/mocks/mock-pack04/npm-install-done`))
+  })
 })
 
 /* global describe, it */


### PR DESCRIPTION
@okunishinishi 
package.json に dependencies はないが postinstall スクリプトなどがある場合、今の実装では npm install をスキップしてしまう。npm scripts をトリガーさせるために node_modules ディレクトリが存在しなければ npm install するように条件を追加した。