### PR TITLE
fix: tollerate loose semver versions

### DIFF
--- a/lib.js
+++ b/lib.js
@@ -103,7 +103,7 @@ installIfNeeded.needsInstall = async (pkg, { cwd }) => {
     const isSemver = Boolean(semver.valid(version) || semver.validRange(version))
     if (isSemver) {
       const pkg = await utils.readFileAsJSON(modulePackagePath)
-      const ok = !!pkg && semver.satisfies(pkg.version, version)
+      const ok = !!pkg && semver.satisfies(pkg.version, version, { loose: true })
       if (!ok) {
         debug('Not specified', name, version)
         return true


### PR DESCRIPTION
I found this change useful when working with a module which has a version which is not strictly correct (`eslint-plugin-lodash-fp`, version `2.2.0a1`, which does not have a hyphen as mandated by https://semver.org/#spec-item-9).
